### PR TITLE
Use index references in view

### DIFF
--- a/src/dict.jl
+++ b/src/dict.jl
@@ -1,13 +1,15 @@
-mutable struct IndexedStructVector{C}
+
+mutable struct IndexedStructVector{S}
     del::Bool
     nextlastid::Int64
+    const index::Vector{Base.RefValue{Int}}
+    const id::Vector{Int}
     const id_to_index::Dict{Int64, Int}
-    const components::C
-    function IndexedStructVector(components::NamedTuple)
-        allequal(length.(values(components))) || error("All components must have equal length")
-        len = length(first(components))
-        comps = merge((ID=collect(1:len),), components)
-        return new{typeof(comps)}(false, len, Dict{Int64,Int}(), comps)
+    const components::S
+    function IndexedStructVector(comps::NamedTuple)
+        allequal(length.(values(comps))) || error("All components must have equal length")
+        len = length(first(comps))
+        return new{typeof(comps)}(false, len, Ref.(collect(1:len)), collect(1:len), Dict{Int64,Int}(), comps)
     end
 end
 
@@ -18,7 +20,7 @@ lastkey(isv::IndexedStructVector) = getfield(isv, :nextlastid)
 @inline function id_guess_to_index(isv::IndexedStructVector, id::Int64, lasti::Int)::Int
     del = getfield(isv, :del)
     comps = getfield(isv, :components)
-    ID = getfield(comps, :ID)
+    ID = getfield(isv, :id)
     if !del
         checkbounds(Bool, ID, id) || throw(KeyError(id))
         id
@@ -33,18 +35,24 @@ end
 
 @inline function delete_id_index!(isv::IndexedStructVector, id::Int64, i::Int)
     comps, id_to_index = getfield(isv, :components), getfield(isv, :id_to_index)
-    del, ID = getfield(isv, :del), getfield(comps, :ID)
+    del, ID, index = getfield(isv, :del), getfield(isv, :id), getfield(isv, :index)
     !del && setfield!(isv, :del, true)
     removei! = a -> remove!(a, i)
     unrolled_map(removei!, values(comps))
+    remove!(ID, i)
+    index[i][] = 0
+    remove!(index, i)
     delete!(id_to_index, id)
-    i <= length(ID) && (id_to_index[(@inbounds ID[i])] = i)
+    if i <= length(ID)
+        index[i][] = i
+        id_to_index[(@inbounds ID[i])] = i
+    end
     return isv
 end
 
 function Base.deleteat!(isv::IndexedStructVector, i::Int)
     comps = getfield(isv, :components)
-    ID = getfield(comps, :ID)
+    ID = getfield(isv, :id)
     delete_id_index!(isv, ID[i], i)
 end
 
@@ -53,19 +61,20 @@ function Base.delete!(isv::IndexedStructVector, id::Int)
     delete_id_index!(isv, id, i)
 end
 
-function Base.delete!(isv::IndexedStructVector, a::IndexedView)
-    id, lasti = getfield(a, :id), getfield(a, :lasti)
-    i = id_guess_to_index(isv, id, lasti)
+function Base.delete!(isv::IndexedStructVector, a::IndexedRefView)
+    lasti = getfield(a, :lasti)[]
+    id = getfield(isv, :id)[lasti]
     delete_id_index!(isv, id, i)
 end
 
 function Base.push!(isv::IndexedStructVector, t::NamedTuple)
     comps, id_to_index = getfield(isv, :components), getfield(isv, :id_to_index)
-    fieldnames(typeof(comps))[2:end] != keys(t) && error("Tuple fields do not match container fields")
-    ID, lastid = getfield(comps, :ID), getfield(isv, :nextlastid)
+    fieldnames(typeof(comps)) != keys(t) && error("Tuple fields do not match container fields")
+    ID, index, lastid = getfield(isv, :id), getfield(isv, :index), getfield(isv, :nextlastid)
     nextlastid = setfield!(isv, :nextlastid, lastid + 1)
     push!(ID, nextlastid)
-    unrolled_map(push!, values(comps)[2:end], t)
+    push!(index, Ref(length(ID)))
+    unrolled_map(push!, values(comps), t)
     getfield(isv, :del) && (id_to_index[nextlastid] = length(ID))
     return isv
 end
@@ -78,25 +87,20 @@ function Base.show(io::IO, ::MIME"text/plain", x::IndexedStructVector{C}) where 
 end
 
 function Base.keys(isv::IndexedStructVector)
-    return Keys(getfield(getfield(isv, :components), :ID))
+    return Keys(getfield(isv, :id))
 end
 
 @inline function Base.getindex(isv::IndexedStructVector, id::Int)
-    return IndexedView(id, id_guess_to_index(isv, id, id), isv)
+    index = getfield(isv, :index)
+    return IndexedRefView(index[id_guess_to_index(isv, id, id)], isv)
 end
 
-function Base.in(a::IndexedView, isv::IndexedStructVector)
-    id, comps = getfield(a, :id), getfield(isv, :components)
-    del, ID = getfield(isv, :del), getfield(comps, :ID)
-    !del && return 1 <= id <= length(ID)
-    lasti = getfield(a, :lasti)
-    lasti <= length(ID) && (@inbounds ID[lasti] == id) && return true
-    id_to_index = getfield(isv, :id_to_index)
-    return id in keys(id_to_index)
+function Base.in(a::IndexedRefView, isv::IndexedStructVector)
+    return getfield(a, :lasti)[] != 0
 end
 function Base.in(id::Int64, isv::IndexedStructVector)
     comps = getfield(isv, :components)
-    del, ID = getfield(isv, :del), getfield(comps, :ID)
+    del, ID = getfield(isv, :del), getfield(isv, :id)
     !del && return 1 <= id <= length(ID)
     id ∈ eachindex(ID) && (@inbounds ID[id] == id) && return true
     id_to_index = getfield(isv, :id_to_index)

--- a/test/test-dict.jl
+++ b/test/test-dict.jl
@@ -14,7 +14,7 @@ using Test
         s = IndexedStructVector((num = [1,2,3], name = ["x","y","z"]))
         a = s[2]
 
-        @test typeof(a) <: IndexedStructVectors.IndexedView
+        @test typeof(a) <: IndexedStructVectors.IndexedRefView
         @test a.num == 2
         @test a.name == "y"
 
@@ -41,15 +41,15 @@ using Test
 
         push!(s, (num = 111, tag = 'z'))
         new_id = IndexedStructVectors.lastkey(s)
-        @test new_id == s[new_id].ID == id(s[new_id]) == 5
+        @test new_id == id(s[new_id]) == 5
         @test new_id in collect(keys(s))
         @test s[new_id].num == 111
 
         delete!(s, 4)
         ids_after = collect(keys(s))
         @test (4 in ids_after) == false
-        @test s.ID[2] == 5
-        @test s[s.ID[2]].num == 111
+        @test getfield(s, :id)[2] == 5
+        @test s[getfield(s, :id)[2]].num == 111
         @test length(ids_after) == 3
 
         @test_throws KeyError delete!(s, 9999)


### PR DESCRIPTION
This makes the code not equivalent to use only a `UniqueVector`, but we could still use it instead of `id_to_index` and `id` I think.

@nhz2 still need to do this in a way not to clash too much with your code 